### PR TITLE
Soluciono error de ruta duplicada al volver atrás en una colección

### DIFF
--- a/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
+++ b/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
@@ -161,19 +161,6 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
       }
     }));
 
-    if (this.router.url?.split('?')[0] === comColRoute) {
-      this.allOptions$.pipe(
-        take(1),
-      ).subscribe((allOptions: ComColPageNavOption[]) => {
-        for (const option of allOptions) {
-          if (option.id === this.appConfig[this.contentType].defaultBrowseTab) {
-            this.currentOption$.next(option[0]);
-            void this.router.navigate([option.routerLink], { queryParams: option.params });
-            break;
-          }
-        }
-      });
-    }
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Al recargar la página y navegar en colecciones se duplicaba la ruta, haciendo que cuando se deseaba volver atrás en realidad se permanecía en la página actual. Esto se debía a un código redundante que agregaba al history de path's dos veces la misma ruta. Este código redundante es el que fue eliminado.