### PR TITLE
Agrego texto predeterminado a los items sin resumen

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7112,6 +7112,10 @@
 
   "sedici.item.page.unknown.author": "Unknown Author",
 
+  // "sedici.item.page.dc.description.no_abstract": "Este item no posee resumen",
+  "sedici.item.page.dc.description.no_abstract": "This item has no abstract",
+
+
   "sedici.item.page.sedici.citation": "Cite",
 
   "sedici.item.page.sedici.share": "Share",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -9954,6 +9954,7 @@
   "search.navbar.placeholder": "Buscar en SEDICI UNLP",
 
   // Vista del ítem
+  "sedici.item.page.dc.description.no_abstract": "Este item no posee resumen",
   "sedici.item.page.unknown.author": "Autor desconocido",
   "sedici.item.page.sedici.citation": "Citar",
   "sedici.item.page.sedici.share": "Compartir",

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -10937,6 +10937,9 @@
 
   "search.navbar.placeholder": "Buscar no SEDICI UNLP",
 
+  // "sedici.item.page.dc.description.no_abstract": "This item has no abstract",
+  "sedici.item.page.dc.description.no_abstract": "Este item não possui resumo",
+
   "sedici.item.page.unknown.author": "Autor desconhecido",
 
   "sedici.item.page.sedici.citation": "Citar",

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.html
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.html
@@ -1,8 +1,13 @@
 <div class="language-switcher-wrapper">
   <div class="language-switcher-container">
     <ds-truncatable [id]="item?.id + 'abstract'">
-      <ds-truncatable-part [id]="item?.id + 'abstract'" [minLines]="6">
-        <span class="abstract-text" [innerHTML]="getAbstract()"></span>
+      <ds-truncatable-part [id]="item?.id + 'abstract'" [minLines]="6" class="abstract-part">
+        @if (!hasAbstract()) {
+          <i class="fa-solid fa-circle-exclamation info-icon"></i>
+          <span class="no-abstract">{{'sedici.item.page.dc.description.no_abstract' | translate}}</span>
+        } @else {
+          <span class="abstract-text" [innerHTML]="getAbstract()"></span>
+        }
       </ds-truncatable-part>
     </ds-truncatable>
   </div>

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.scss
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.scss
@@ -65,6 +65,17 @@
   text-align: justify;
 }
 
+.no-abstract {
+  color: #413f3f;
+  font-size: 14px;
+  font-style: italic;
+}
+
+.info-icon {
+    color: #706f6f;
+    margin-right: 4px;
+}
+
 ::ng-deep .language-switcher-wrapper ds-truncatable-part .collapseButton,
 ::ng-deep .language-switcher-wrapper ds-truncatable-part .expandButton {
   margin-left: auto;

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.ts
@@ -19,26 +19,27 @@ export class LanguageSwitcherComponent {
   @Input() item: any;
   selectedLanguage: string;
   availableLanguages: any[];
+  abstracts: any[];
 
   constructor(private sanitizer: DomSanitizer) {}
 
   ngOnInit() {
     const langValue = this.item.metadata['dc.language']?.[0]?.value;
     this.selectedLanguage = !langValue || langValue === 'other' ? '??' : langValue;
+    this.abstracts = this.item.metadata['dc.description.abstract'];
     this.availableLanguages = this.getAvailableLanguages();
   }
 
   hasAbstract(): boolean {
-    return !!this.item.metadata['dc.description.abstract'];
+    return this.abstracts && this.abstracts.length > 0;
   }
 
   getAbstract(): SafeHtml {
-    const abstracts = this.item.metadata['dc.description.abstract'];
-    if (abstracts) {
-      let abstract = abstracts.find((abstract: any) => (abstract.language || '??') === this.selectedLanguage)?.value || '';
+    if (this.abstracts) {
+      let abstract = this.abstracts.find((abstract: any) => (abstract.language || '??') === this.selectedLanguage)?.value || '';
       if (!abstract) {
-        abstract = abstracts[0].value;
-        this.selectedLanguage = abstracts[0].language;
+        abstract = this.abstracts[0].value;
+        this.selectedLanguage = this.abstracts[0].language;
       }
       return this.sanitizer.bypassSecurityTrustHtml(abstract);
     }
@@ -50,9 +51,8 @@ export class LanguageSwitcherComponent {
   }
 
   getAvailableLanguages() {
-    const abstracts = this.item.metadata['dc.description.abstract'];
-    if (abstracts) {
-      return [...new Set(abstracts.map((abstract: any) => (abstract.language || '??')))];
+    if (this.abstracts) {
+      return [...new Set(this.    abstracts.map((abstract: any) => (abstract.language || '??')))];
     }
     return [];
   }

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-
 import { TranslateModule } from '@ngx-translate/core';
 import { TruncatableComponent } from 'src/app/shared/truncatable/truncatable.component';
 import { TruncatablePartComponent } from 'src/app/shared/truncatable/truncatable-part/truncatable-part.component';
@@ -27,6 +26,10 @@ export class LanguageSwitcherComponent {
     const langValue = this.item.metadata['dc.language']?.[0]?.value;
     this.selectedLanguage = !langValue || langValue === 'other' ? '??' : langValue;
     this.availableLanguages = this.getAvailableLanguages();
+  }
+
+  hasAbstract(): boolean {
+    return !!this.item.metadata['dc.description.abstract'];
   }
 
   getAbstract(): SafeHtml {

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/language-switcher.component.ts
@@ -52,7 +52,7 @@ export class LanguageSwitcherComponent {
 
   getAvailableLanguages() {
     if (this.abstracts) {
-      return [...new Set(this.    abstracts.map((abstract: any) => (abstract.language || '??')))];
+      return [...new Set(this.abstracts.map((abstract: any) => (abstract.language || '??')))];
     }
     return [];
   }


### PR DESCRIPTION
Cuando un item no tenía un resumen, aparecía el espacio para el resumen sin  ningún texto. Lo que hice fue agregar en el mismo lugar  un texto informativo mencionando que ese item no tiene ningún resumen.

<img width="1279" height="388" alt="Captura desde 2025-10-02 09-07-57" src="https://github.com/user-attachments/assets/2484ebbe-a11b-4a1e-ac8e-8150cd2dade5" />