### PR TITLE
solución a error que no mostraba bien cuando un archivo está embargado

### DIFF
--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/content-files.component.html
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/content-files.component.html
@@ -39,7 +39,7 @@
             }
           </div>
           <div class="file-preview d-none d-lg-block col-lg-9">
-            @if (selectedFile && isAssetAvailable) {
+            @if (selectedFile && isAssetAvailable && !embargoedFile) {
               <div>
                 <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
               </div>
@@ -47,6 +47,10 @@
               @if (!isAssetAvailable) {
                 <div class="no-preview">
                   <span>OCURRIÓ UN ERROR INESPERADO: PREVISUALIZACIÓN NO DISPONIBLE</span>
+                </div>
+              } @else if (embargoedFile) {
+                <div class="no-preview">
+                  <span>ARCHIVO EMBARGADO</span>
                 </div>
               } @else {
                 <div class="no-preview">

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/content-files.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/content-files.component.ts
@@ -162,6 +162,8 @@ export class ContentFilesComponent {
                 }  
                 this.isLoading = false;
               });
+            } else {
+              this.embargoedFile = true;
             }
             this.isLoading = false;
             this.cdr.detectChanges();


### PR DESCRIPTION
Se crea el PR para ir solucionando errores que puedan ocurrir durante las pruebas realizadas con la vista de documentos embargados